### PR TITLE
Add vault to vault transfer

### DIFF
--- a/test/fuzz/Vault.t.sol
+++ b/test/fuzz/Vault.t.sol
@@ -47,7 +47,7 @@ contract VaultFuzzTest is ERC4626Test, Helpers {
 
     prizeToken = new ERC20Mock();
 
-    twabController = new TwabController();
+    twabController = new TwabController(drawPeriodSeconds);
 
     prizePool = new PrizePoolMock(prizeToken);
 

--- a/test/unit/Vault/Migrate.feature
+++ b/test/unit/Vault/Migrate.feature
@@ -1,0 +1,91 @@
+Feature: Migrate
+  # redeemTo
+  Scenario: Alice migrates her full deposit to another Vault
+    Given Alice owns 1,000 Vault shares
+    When Alice `redeemToVault` her full deposit
+    Then Alice's Vault shares must be burnt
+    Then Alice must receive new Vault shares from the other Vault
+    Then Alice `balance` for the current Vault must be equal to 0
+    Then Alice `delegateBalance` for the current Vault must be equal to 0
+    Then the current Vault balance of YieldVault shares must be equal to 0
+    Then the current YieldVault balance of underlying assets must be equal to 0
+    Then Alice `balance` for the new Vault must be equal to 1,000
+    Then Alice `delegateBalance` for the new Vault must be equal to 1,000
+    Then the new Vault balance of YieldVault shares must be equal to 0
+    Then the new YieldVault balance of underlying assets must be equal to 0
+
+
+
+
+
+
+  Scenario: Alice withdraws half of her deposit
+    Given Alice owns 1,000 Vault shares
+    When Alice `withdraw` 500 underlying assets
+    Then half of Alice's Vault shares must be burnt
+    Then Alice must receive half of her deposit back
+    Then Alice `balance` must be equal to 500
+    Then Alice `delegateBalance` must be equal to 500
+    Then the Vault balance of YieldVault shares must decrease by half
+    Then the YieldVault balance of underlying assets must decrease by half
+
+  Scenario: Alice withdraws her full deposit after yield has accrued
+    Given Alice owns 1,000 Vault shares and 10 underlying assets have accrued in the YieldVault
+    When Alice `withdraw` her full deposit
+    Then Alice's Vault shares must be burnt
+    Then Alice must receive her full deposit back
+    Then Alice `balance` must be equal to 0
+    Then Alice `delegateBalance` must be equal to 0
+    Then the Vault balance of YieldVault shares must be equivalent to the amount of yield accrued
+    Then the YieldVault balance of underlying assets must be equal to the amount of yield accrued
+
+  Scenario: Alice withdraws Bob full deposit on his behalf
+    Given Bob owns 1,000 Vault shares and has approved Alice to spend his tokens
+    When Alice `withdraw` Bob full deposit
+    Then Bob's Vault shares must be burnt
+    Then Bob must receive his full deposit back
+    Then Bob `balance` must be equal to 0
+    Then Bob `delegateBalance` must be equal to 0
+    Then the Vault balance of YieldVault shares must be equal to 0
+    Then the YieldVault balance of underlying assets must be equal to 0
+
+  # Redeem
+  Scenario: Alice redeems her full deposit
+    Given Alice owns 1,000 Vault shares
+    When Alice `redeem` her full deposit
+    Then Alice's Vault shares must be burnt
+    Then Alice must receive her full deposit back
+    Then Alice `balance` must be equal to 0
+    Then Alice `delegateBalance` must be equal to 0
+    Then the Vault balance of YieldVault shares must be equal to 0
+    Then the YieldVault balance of underlying assets must be equal to 0
+
+  Scenario: Alice redeems half of her deposit
+    Given Alice owns 1,000 Vault shares
+    When Alice `redeem` 500 underlying assets
+    Then half of Alice's Vault shares must be burnt
+    Then Alice must receive half of her deposit back
+    Then Alice `balance` must be equal to 500
+    Then Alice `delegateBalance` must be equal to 500
+    Then the Vault balance of YieldVault shares must decrease by half
+    Then the YieldVault balance of underlying assets must decrease by half
+
+  Scenario: Alice redeems her full deposit after yield has accrued
+    Given Alice owns 1,000 Vault shares and 10 underlying assets have accrued in the YieldVault
+    When Alice `redeem` her full deposit
+    Then Alice's Vault shares must be burnt
+    Then Alice must receive her full deposit back
+    Then Alice `balance` must be equal to 0
+    Then Alice `delegateBalance` must be equal to 0
+    Then the Vault balance of YieldVault shares must be equivalent to the amount of yield accrued
+    Then the YieldVault balance of underlying assets must be equal to the amount of yield accrued
+
+  Scenario: Alice redeems Bob full deposit on his behalf
+    Given Bob owns 1,000 Vault shares and has approved Alice to spend his tokens
+    When Alice `redeem` Bob full deposit
+    Then Bob's Vault shares must be burnt
+    Then Bob must receive his full deposit back
+    Then Bob `balance` must be equal to 0
+    Then Bob `delegateBalance` must be equal to 0
+    Then the Vault balance of YieldVault shares must be equal to 0
+    Then the YieldVault balance of underlying assets must be equal to 0

--- a/test/unit/Vault/Migrate.t.sol
+++ b/test/unit/Vault/Migrate.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+import { UnitBaseSetup, IERC20, PrizePool, Vault } from "test/utils/UnitBaseSetup.t.sol";
+
+contract VaultMigrateTest is UnitBaseSetup {
+  /* ============ Events ============ */
+  event MigrateToVault(
+    Vault indexed fromVault,
+    Vault indexed toVault,
+    address indexed caller,
+    uint256 assets,
+    uint256 shares
+  );
+
+  /* ============ Variables ============ */
+  Vault public toVault;
+
+  /* ============ Setup ============ */
+  function setUp() public override {
+    super.setUp();
+
+    toVault = new Vault(
+      underlyingAsset,
+      vaultName,
+      vaultSymbol,
+      twabController,
+      yieldVault,
+      PrizePool(address(prizePool)),
+      claimer,
+      address(this),
+      0,
+      address(this)
+    );
+  }
+
+  /* ============ Tests ============ */
+
+  /* ============ Withdraw ============ */
+  function testRedeemToVaultSameYieldVault() external {
+    vm.startPrank(alice);
+
+    uint256 _amount = 1000e18;
+    underlyingAsset.mint(alice, _amount);
+    _deposit(underlyingAsset, vault, _amount, alice);
+
+    uint256 _shares = vault.convertToShares(_amount);
+
+    vm.expectEmit();
+    emit MigrateToVault(vault, toVault, alice, _amount, _shares);
+
+    vault.redeemToVault(toVault, vault.maxRedeem(alice));
+
+    // assertEq(vault.balanceOf(alice), 0);
+    // assertEq(underlyingAsset.balanceOf(alice), _amount);
+
+    // assertEq(twabController.balanceOf(address(vault), alice), 0);
+    // assertEq(twabController.delegateBalanceOf(address(vault), alice), 0);
+
+    // assertEq(yieldVault.balanceOf(address(vault)), 0);
+    // assertEq(underlyingAsset.balanceOf(address(yieldVault)), 0);
+
+    vm.stopPrank();
+  }
+}

--- a/test/unit/VaultFactory.t.sol
+++ b/test/unit/VaultFactory.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
 import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
 
@@ -20,14 +20,20 @@ contract VaultFactoryTest is Test {
   /* ============ Variables ============ */
   VaultFactory public vaultFactory;
 
-  ERC20Mock public asset = new ERC20Mock();
+  ERC20Mock public underlyingAsset = new ERC20Mock();
   string public name = "PoolTogether aEthDAI Yield (PTaEthDAIY)";
   string public symbol = "PTaEthDAIY";
 
   TwabController public twabController =
     TwabController(address(0xDEBef0AD51fEF36a8ea13eEDA6B60Da2fef675cD));
 
-  YieldVault public yieldVault = YieldVault(address(0xc24F43A638E2c32995108415fb3EB402Cd675580));
+  YieldVault public yieldVault =
+    new YieldVault(
+      address(underlyingAsset),
+      "PoolTogether aEthDAI Yield (PTaEthDAIY)",
+      "PTaEthDAIY"
+    );
+
   PrizePool public prizePool = PrizePool(address(0x46fdfAdF967526047175693C751c920f786248C9));
   Claimer public claimer = Claimer(address(0xB6719828701798673852BceCadB764aaf26e8814));
 
@@ -45,7 +51,7 @@ contract VaultFactoryTest is Test {
     emit NewFactoryVault(Vault(_vault), vaultFactory);
 
     _vault = vaultFactory.deployVault(
-      asset,
+      underlyingAsset,
       name,
       symbol,
       twabController,

--- a/test/utils/UnitBaseSetup.t.sol
+++ b/test/utils/UnitBaseSetup.t.sol
@@ -63,7 +63,7 @@ contract UnitBaseSetup is Test, Helpers {
     underlyingAsset = new ERC20PermitMock("Dai Stablecoin");
     prizeToken = new ERC20PermitMock("PoolTogether");
 
-    twabController = new TwabController();
+    twabController = new TwabController(drawPeriodSeconds);
 
     prizePool = new PrizePoolMock(prizeToken);
 

--- a/test/utils/UnitBaseSetup.t.sol
+++ b/test/utils/UnitBaseSetup.t.sol
@@ -54,7 +54,7 @@ contract UnitBaseSetup is Test, Helpers {
 
   /* ============ Setup ============ */
 
-  function setUp() public {
+  function setUp() public virtual {
     (owner, ownerPrivateKey) = makeAddrAndKey("Owner");
     (manager, managerPrivateKey) = makeAddrAndKey("Manager");
     (alice, alicePrivateKey) = makeAddrAndKey("Alice");


### PR DESCRIPTION
This PR has been canceled for the following reason.

Maybe this is a feature we could build into a wrapper contract but it doesn't make a lot of sense to bake it into the Vault.

On average, this is how much gas it costs to:

deposit: 203243

withdraw: 74455

redeemToVault: 280854

203243 + 74455 = 277698

So it costs about the same to withdraw then deposit into another Vault than to do it in one go through the Vault.

Plus, there is the added complexity of whitelisting the Vaults users can migrate to since the origin Vault needs to approve the destination Vault to spend the underlying assets.