### PR TITLE
docs: add contribution badge to README linking to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Code Coverage](https://github.com/pooltogether/v5-vault/actions/workflows/coverage.yml/badge.svg)](https://github.com/pooltogether/v5-vault/actions/workflows/coverage.yml)
 [![built-with openzeppelin](https://img.shields.io/badge/built%20with-OpenZeppelin-3677FF)](https://docs.openzeppelin.com/)
 [![GPLv3 license](https://img.shields.io/badge/License-GPLv3-blue.svg)](http://perso.crans.org/besson/LICENSE.html)
+[![Contributing](https://img.shields.io/badge/Contributions-Welcome-success.svg)](./CONTRIBUTING.md)
 
 <strong>Have questions or want the latest news?</strong>
 <br/>Join the PoolTogether Discord or follow us on Twitter:


### PR DESCRIPTION
This commit adds a new "Contributions Welcome" badge to the README file. The badge links directly to the CONTRIBUTING.md guide, making it easier for new contributors to find contribution instructions and guidelines.

This is a documentation-only change and does not affect the codebase.